### PR TITLE
Add option to compute total count of replays with given filters

### DIFF
--- a/src/model/rest-api/replays.ts
+++ b/src/model/rest-api/replays.ts
@@ -37,6 +37,7 @@ export const replaysQuerySchema = paginateQuerySchema(Type.Object({
             Type.Number()
         ])
     ),
+    computeTotalResults: Type.Boolean({ default: false }),
 }));
 
 export type ReplaysQueryType = Static<typeof replaysQuerySchema>;


### PR DESCRIPTION
It was dropped to save on performance, but there ended up being valid usecases for it so let's add it back behind query option.